### PR TITLE
Export unset fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@
 #    By: akovalev <akovalev@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/01/30 13:42:54 by rboudwin          #+#    #+#              #
-#    Updated: 2024/03/22 16:18:01 by akovalev         ###   ########.fr        #
+#    Updated: 2024/04/02 10:39:50 by rboudwin         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 NAME	:= minishell 
 #CFLAGS	:= -Wextra -Wall -Werror -Wunreachable-code -Ofast 
-CFLAGS := -I /Users/$(USER)/.brew/opt/readline/include
+CFLAGS := -I /Users/$(USER)/.brew/opt/readline/include -fsanitize=address
 LDFLAGS := -L /Users/$(USER)/.brew/opt/readline/lib
 SRCS	:= main.c signals.c parsing.c env_handling.c tools.c built_in.c \
 			built_in2.c env_and_quote_handler.c heredoc.c
@@ -24,7 +24,7 @@ all: $(NAME)
 	@$(CC) $(CFLAGS) -o $@ -c $< 
 
 $(NAME): $(OBJS) 
-	@$(CC) $(OBJS) -o $(NAME) $(LDFLAGS) -lreadline -ltermcap -lncurses
+	@$(CC) $(OBJS) -o $(NAME) $(LDFLAGS) -lreadline -ltermcap -lncurses -fsanitize=address
 #-ltermcap -lncurses might be needed for termcap stuff like save/restore cursor
 
 Libft/libft.a: 

--- a/built_in.c
+++ b/built_in.c
@@ -6,7 +6,7 @@
 /*   By: rboudwin <rboudwin@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 10:09:19 by rboudwin          #+#    #+#             */
-/*   Updated: 2024/04/01 16:15:46 by rboudwin         ###   ########.fr       */
+/*   Updated: 2024/04/01 18:29:52 by rboudwin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,7 @@ void	ft_cd(t_execcmd *ecmd, t_info *info)
 	free(info->prompt);
 	info->prompt = ft_prompt(info->username, "AR-Shell", info->curr_dir);
 	free(home_path);
+	home_path = NULL;
 }
 
 void	ft_pwd(t_execcmd *ecmd, t_info *info)
@@ -102,6 +103,6 @@ void	handle_builtins(t_execcmd *ecmd, char **env,
 		ft_export(ecmd, info); //we may not want this running in the child processes
 	if (!ft_strncmp(builtin_command, "exit", ft_strlen(builtin_command)))
 		ft_exit(ecmd, info);
-	//if (!ft_strncmp(builtin_command, "unset", ft_strlen(builtin_command)))
-		//ft_unset(ecmd, info);
+	if (!ft_strncmp(builtin_command, "unset", ft_strlen(builtin_command)))
+		ft_unset(ecmd, info);
 }

--- a/built_in2.c
+++ b/built_in2.c
@@ -6,7 +6,7 @@
 /*   By: rboudwin <rboudwin@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 11:30:34 by rboudwin          #+#    #+#             */
-/*   Updated: 2024/04/02 11:36:53 by rboudwin         ###   ########.fr       */
+/*   Updated: 2024/04/02 15:42:18 by rboudwin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,7 +92,7 @@ void	ft_export(t_execcmd *ecmd, t_info *info)
 	}
 	k = 1;
 	curr_len = ft_matrix_len(info->curr_env);
-	ft_printf("current length of curr_env is %d\n", curr_len);
+//	ft_printf("current length of curr_env is %d\n", curr_len);
 	target_len = curr_len + ft_matrix_len(ecmd->argv);
 	//target_len = curr_len + ft_matrix_len(&ecmd->argv[k]);
 	//new_env = malloc(sizeof(char *) * (target_len + 1)); //this might be mallocing more than we need.
@@ -168,7 +168,7 @@ char	*search_matrix(char *arg, char **matrix, int *i, int curr_len)
 			(*i)++;
 		else if (!ft_strncmp(matrix[*i], arg_plus, ft_strlen(arg_plus)) || !ft_strncmp(matrix[*i], arg, ft_strlen(arg) + 1))
 			{
-				ft_printf("we found it baby: %s\n", matrix[*i]);
+				//ft_printf("we found it baby: %s\n", matrix[*i]);
 				free(arg_plus);
 				arg_plus = NULL;
 				return (matrix[*i]);
@@ -203,20 +203,20 @@ void	ft_unset(t_execcmd *ecmd, t_info *info)
 		// if we find a bad one we just wanna move on
 		if (!str)
 		{
-			ft_printf("we concluded that %s isn't actually in the matrix so moving on\n", ecmd->argv[k]);
+			///ft_printf("we concluded that %s isn't actually in the matrix so moving on\n", ecmd->argv[k]);
 			k++;
 		}
 		else
 		{
-			ft_printf("we found %s in the matrix so we are freeing it\n", ecmd->argv[k]);
-			ft_printf("str is '%s' and info->curr_env[%d] is currently '%s'\n", str, i, info->curr_env[i]);
+			//ft_printf("we found %s in the matrix so we are freeing it\n", ecmd->argv[k]);
+			//ft_printf("str is '%s' and info->curr_env[%d] is currently '%s'\n", str, i, info->curr_env[i]);
 			free(info->curr_env[i]);
 			info->curr_env[i] = NULL;
 			i = 0;
 			k++;
 		}
 	}
-	new_env = ft_calloc(sizeof(char *),(curr_len + 1));
+	new_env = ft_calloc(sizeof(char *), (curr_len + 1));
 	if (!new_env)
 		exit(1);
 	a = 0;
@@ -227,11 +227,11 @@ void	ft_unset(t_execcmd *ecmd, t_info *info)
 		{
 			new_env[a] = info->curr_env[b];
 			a++;
-		}		
-		b++;	
+		}
+		b++;
 	}
 	new_env[a] = NULL;
-	free(info->curr_env); //This should be causing leaks surely
+	free(info->curr_env);
 	info->curr_env = NULL;
 	info->curr_env = new_env;
 }

--- a/built_in2.c
+++ b/built_in2.c
@@ -6,7 +6,7 @@
 /*   By: rboudwin <rboudwin@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 11:30:34 by rboudwin          #+#    #+#             */
-/*   Updated: 2024/04/01 18:11:38 by rboudwin         ###   ########.fr       */
+/*   Updated: 2024/04/01 18:28:09 by rboudwin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -230,6 +230,7 @@ void	ft_unset(t_execcmd *ecmd, t_info *info)
 		b++;	
 	}
 	new_env[++a] = NULL;
-	free(info->curr_env);
+	//free(info->curr_env); This should be causing leaks surely
+	info->curr_env = NULL;
 	info->curr_env = new_env;
 }

--- a/built_in2.c
+++ b/built_in2.c
@@ -6,7 +6,7 @@
 /*   By: rboudwin <rboudwin@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 11:30:34 by rboudwin          #+#    #+#             */
-/*   Updated: 2024/04/01 18:28:09 by rboudwin         ###   ########.fr       */
+/*   Updated: 2024/04/02 09:56:43 by rboudwin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ char	*var_to_equals(t_execcmd *ecmd, int k)
 		return (NULL);
 	else
 	{
-		needle = malloc(equal_pos - ecmd->argv[k] + 1);
+		needle = ft_calloc(equal_pos - ecmd->argv[k] + 1, 1);
 		if (!needle)
 			return (NULL);
 		while (ecmd->argv[k][i] && ecmd->argv[k][i] != '=')
@@ -95,13 +95,15 @@ void	ft_export(t_execcmd *ecmd, t_info *info)
 	ft_printf("current length of curr_env is %d\n", curr_len);
 	target_len = curr_len + ft_matrix_len(ecmd->argv);
 	//target_len = curr_len + ft_matrix_len(&ecmd->argv[k]);
-	new_env = malloc(sizeof(char *) * (target_len + 1)); //this might be mallocing more than we need.
+	//new_env = malloc(sizeof(char *) * (target_len + 1)); //this might be mallocing more than we need.
+	new_env = ft_calloc(sizeof(char *), target_len + 1);
 	if (!new_env)
 	{
 		ft_printf("malloc failure\n");
 		exit(1);
 	}
-	ft_bzero(new_env, sizeof(char *) * (target_len + 1)); // this fixes undefined behavior
+	//no longer required because we swapped to calloc
+	//ft_bzero(new_env, sizeof(char *) * (target_len + 1)); // this fixes undefined behavior
 	i = 0;
 	while (info->curr_env[i])
 	{
@@ -214,10 +216,9 @@ void	ft_unset(t_execcmd *ecmd, t_info *info)
 			k++;
 		}
 	}
-	new_env = malloc(sizeof(char *) * (curr_len + 1));
+	new_env = ft_calloc(sizeof(char *),(curr_len + 1));
 	if (!new_env)
 		exit(1);
-	ft_bzero(new_env, sizeof(char *) * (curr_len + 1)); // this fixes undefined behavior
 	a = 0;
 	b = 0;
 	while (b < curr_len)

--- a/built_in2.c
+++ b/built_in2.c
@@ -6,7 +6,7 @@
 /*   By: rboudwin <rboudwin@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 11:30:34 by rboudwin          #+#    #+#             */
-/*   Updated: 2024/04/02 09:56:43 by rboudwin         ###   ########.fr       */
+/*   Updated: 2024/04/02 11:02:19 by rboudwin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -230,8 +230,8 @@ void	ft_unset(t_execcmd *ecmd, t_info *info)
 		}		
 		b++;	
 	}
-	new_env[++a] = NULL;
-	//free(info->curr_env); This should be causing leaks surely
+	new_env[a] = NULL;
+	//free(info->curr_env); //This should be causing leaks surely
 	info->curr_env = NULL;
 	info->curr_env = new_env;
 }

--- a/built_in2.c
+++ b/built_in2.c
@@ -6,7 +6,7 @@
 /*   By: rboudwin <rboudwin@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 11:30:34 by rboudwin          #+#    #+#             */
-/*   Updated: 2024/04/02 11:02:19 by rboudwin         ###   ########.fr       */
+/*   Updated: 2024/04/02 11:36:53 by rboudwin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -231,7 +231,7 @@ void	ft_unset(t_execcmd *ecmd, t_info *info)
 		b++;	
 	}
 	new_env[a] = NULL;
-	//free(info->curr_env); //This should be causing leaks surely
+	free(info->curr_env); //This should be causing leaks surely
 	info->curr_env = NULL;
 	info->curr_env = new_env;
 }

--- a/main.c
+++ b/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: akovalev <akovalev@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: rboudwin <rboudwin@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/26 18:01:40 by rboudwin          #+#    #+#             */
-/*   Updated: 2024/03/28 18:32:56 by akovalev         ###   ########.fr       */
+/*   Updated: 2024/04/02 11:23:47 by rboudwin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -120,7 +120,7 @@ int	main(int argc, char **argv, char **env)
 	parsing(&info);
 	//readline();
 	//cleanup
-
+	write_history(".shell_history");
 	free(info.username);
 	free(info.init_dir);
 	free(info.prompt);

--- a/parsing.c
+++ b/parsing.c
@@ -6,7 +6,7 @@
 /*   By: rboudwin <rboudwin@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/05 14:36:57 by akovalev          #+#    #+#             */
-/*   Updated: 2024/03/29 13:04:25 by rboudwin         ###   ########.fr       */
+/*   Updated: 2024/04/02 11:22:32 by rboudwin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -721,6 +721,7 @@ int	parsing(t_info *info)
 		}
 		free (tmp);
 		pstr = str;
+		add_history(str);
 		//printf("Command before expansion: %s\n", str);
 		expanded = expand_env_remove_quotes(str, info->curr_env);
 		//str = pstr;


### PR DESCRIPTION
Switched to using ft_calloc instead of zeroing things separately, and removed an unnecessary prefix operator that was causing us to go out of bounds and get heap overflow errors in unset.