### PR TITLE
now disabling ctrl-c in parent while child is running

### DIFF
--- a/parsing.c
+++ b/parsing.c
@@ -6,7 +6,7 @@
 /*   By: rboudwin <rboudwin@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/05 14:36:57 by akovalev          #+#    #+#             */
-/*   Updated: 2024/04/05 13:59:01 by rboudwin         ###   ########.fr       */
+/*   Updated: 2024/04/05 15:41:07 by rboudwin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -653,7 +653,9 @@ int	parsing(t_info *info)
 			signal(SIGQUIT, SIG_DFL);
 			execute(cmd, info->curr_env, info);
 		}
+		signal(SIGINT, SIG_IGN);
 		wait(&status);
+		set_signal_action();
 		if (WIFEXITED(status))
 		{
 			info->exit_code = WEXITSTATUS(status);


### PR DESCRIPTION
We were getting a lot of strange prompt behavior when ctrl-C is used while a child process is running.

The change here will disable the SIGINT signal in the parent process after a fork, until the child process is resolved, then turns it back on.

Seems to resolve all of our strange prompt behavior.